### PR TITLE
Fix mkdir -p http/players

### DIFF
--- a/bin/build-players.sh
+++ b/bin/build-players.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 DIR=$1
+mkdir -p $DIR/players
 python players.py $DIR/players


### PR DESCRIPTION
It seems that http/players ain't created anywhere.
Without fix:
```
$ make
bin/build-rankings.sh config/dates.json http
python editions.py http/index.html
python editions.py http/2017-01.html
htmlmin http/index.html http/index.html.tmp
mv http/index.html.tmp http/index.html
htmlmin http/2017-01.html http/2017-01.html.tmp
mv http/2017-01.html.tmp http/2017-01.html
bin/build-players.sh http
Traceback (most recent call last):
  File "players.py", line 79, in <module>
    file(os.path.join(output_directory, '%d.html' % pid), 'w').write(template.prettify().encode('utf-8'))
IOError: [Errno 2] No such file or directory: 'http/players/8195.html'
Makefile:24: recipe for target 'players' failed
make: *** [players] Error 1
```